### PR TITLE
Fix for wrong animation duration

### DIFF
--- a/CircleProgressBarDemo/CircleProgressBar/CircleProgressBar.m
+++ b/CircleProgressBarDemo/CircleProgressBar/CircleProgressBar.m
@@ -27,7 +27,7 @@ const StringGenerationBlock DefaultHintTextGenerationBlock = ^NSString *(CGFloat
 
 // Animation Constants
 const CGFloat AnimationChangeTimeDuration = 0.2f;
-const CGFloat AnimationChangeTimeStep = 0.01f;
+const CGFloat AnimationChangeTimeStep = 1/30.0f;
 
 @interface CircleProgressBar (Private)
 


### PR DESCRIPTION
This forces the progress bar to update at 30FPS.